### PR TITLE
Cn producttype2

### DIFF
--- a/ecommerceapi/fixtures/product.json
+++ b/ecommerceapi/fixtures/product.json
@@ -28,5 +28,65 @@
             "created_at": "2019-05-23T14:09:23.047Z",
             "product_type_id": 2
         }
+    },
+    {
+        "model": "ecommerceapi.product",
+        "pk": 3,
+        "fields": {
+            "title": "Death Ray",
+            "customer_id": 2,
+            "price": 500.00,
+            "description": "Kills in one shot, guaranteed.",
+            "quantity": 1,
+            "location": "Ontario",
+            "image": "death_ray.jpeg",
+            "created_at": "2019-04-23T14:09:23.047Z",
+            "product_type_id": 3
+        }
+    },
+    {
+        "model": "ecommerceapi.product",
+        "pk": 4,
+        "fields": {
+            "title": "Siberian Tiger Fur Rug",
+            "customer_id": 2,
+            "price": 500.00,
+            "description": "Alyssa disapproves, but it's still really soft.",
+            "quantity": 1,
+            "location": "Ontario",
+            "image": "death_ray.jpeg",
+            "created_at": "2019-04-23T14:09:23.047Z",
+            "product_type_id": 4
+        }
+    },
+    {
+        "model": "ecommerceapi.product",
+        "pk": 4,
+        "fields": {
+            "title": "Dragon Tooth",
+            "customer_id": 2,
+            "price": 1000000000.00,
+            "description": "You can craft the best weapon in the game with this thing.",
+            "quantity": 1,
+            "location": "Ontario",
+            "image": "death_ray.jpeg",
+            "created_at": "2019-04-23T14:09:23.047Z",
+            "product_type_id": 4
+        }
+    },
+    {
+        "model": "ecommerceapi.product",
+        "pk": 4,
+        "fields": {
+            "title": "Dragon Tooth",
+            "customer_id": 2,
+            "price": 1000000000.00,
+            "description": "You can craft the best weapon in the game with this thing.",
+            "quantity": 1,
+            "location": "Ontario",
+            "image": "death_ray.jpeg",
+            "created_at": "2019-04-23T14:09:23.047Z",
+            "product_type_id": 4
+        }
     }
 ]

--- a/ecommerceapi/fixtures/product.json
+++ b/ecommerceapi/fixtures/product.json
@@ -18,6 +18,36 @@
         "model": "ecommerceapi.product",
         "pk": 2,
         "fields": {
+            "title": "Falafel",
+            "customer_id": 1,
+            "price": 8.00,
+            "description": "It's good when it's good, but dear god it's bad when it's bad",
+            "quantity": 5,
+            "location": "Nashville",
+            "image": "falafel.jpeg",
+            "created_at": "2019-10-23T14:02:23.047Z",
+            "product_type_id": 1
+        }
+    },
+    {
+        "model": "ecommerceapi.product",
+        "pk": 3,
+        "fields": {
+            "title": "Candied Ants",
+            "customer_id": 1,
+            "price": 50.00,
+            "description": "What? Have you even tried them? They're good.",
+            "quantity": 5,
+            "location": "Nashville",
+            "image": "ants.jpeg",
+            "created_at": "2019-10-23T14:02:23.047Z",
+            "product_type_id": 1
+        }
+    },
+    {
+        "model": "ecommerceapi.product",
+        "pk": 4,
+        "fields": {
             "title": "Piano",
             "customer_id": 2,
             "price": 5.00,
@@ -31,14 +61,14 @@
     },
     {
         "model": "ecommerceapi.product",
-        "pk": 3,
+        "pk": 5,
         "fields": {
             "title": "Death Ray",
             "customer_id": 2,
             "price": 500.00,
             "description": "Kills in one shot, guaranteed.",
             "quantity": 1,
-            "location": "Ontario",
+            "location": "Nashville",
             "image": "death_ray.jpeg",
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 3
@@ -46,45 +76,60 @@
     },
     {
         "model": "ecommerceapi.product",
-        "pk": 4,
+        "pk": 6,
         "fields": {
             "title": "Siberian Tiger Fur Rug",
             "customer_id": 2,
             "price": 500.00,
             "description": "Alyssa disapproves, but it's still really soft.",
             "quantity": 1,
-            "location": "Ontario",
-            "image": "death_ray.jpeg",
+            "location": "Nashville",
+            "image": "tiger_fur.jpeg",
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 4
         }
     },
     {
         "model": "ecommerceapi.product",
-        "pk": 4,
+        "pk": 7,
         "fields": {
             "title": "Dragon Tooth",
             "customer_id": 2,
             "price": 1000000000.00,
             "description": "You can craft the best weapon in the game with this thing.",
             "quantity": 1,
-            "location": "Ontario",
-            "image": "death_ray.jpeg",
+            "location": null,
+            "image": "dragon_tooth.jpeg",
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 4
         }
     },
     {
         "model": "ecommerceapi.product",
-        "pk": 4,
+        "pk": 8,
         "fields": {
-            "title": "Dragon Tooth",
+            "title": "Pangolin Scales",
             "customer_id": 2,
-            "price": 1000000000.00,
-            "description": "You can craft the best weapon in the game with this thing.",
+            "price": 100.00,
+            "description": "You could make, like a.... uh... cool skirt or something with these.",
             "quantity": 1,
-            "location": "Ontario",
-            "image": "death_ray.jpeg",
+            "location": "Nashville",
+            "image": "pangolin_scales.jpeg",
+            "created_at": "2019-04-23T14:09:23.047Z",
+            "product_type_id": 4
+        }
+    },
+    {
+        "model": "ecommerceapi.product",
+        "pk": 9,
+        "fields": {
+            "title": "Blue Whale Fat",
+            "customer_id": 2,
+            "price": 9.99,
+            "description": "You can make a fine perfume with this stuff",
+            "quantity": 1,
+            "location": "Nashville",
+            "image": "whale_fat.jpeg",
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 4
         }

--- a/ecommerceapi/views/product.py
+++ b/ecommerceapi/views/product.py
@@ -20,7 +20,7 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
             view_name='product',
             lookup_field='id'
         )
-        fields = ('id', 'title', 'customer', 'price', 'description', 'quantity', 'location', 'image', 'created_at', 'product_type')
+        fields = fields = ('id', 'title', 'customer', 'price', 'description', 'quantity', 'location', 'image', 'created_at', 'product_type', 'product_type_id')
 
 
 class Product(ViewSet):


### PR DESCRIPTION
closes #11

git fetch --all

git checkout cn-producttype2

Summary of this pull request:
All product types will show when the Product Category tab is clicked. Details of a product can be viewed by clicking any given product

Product details can be viewed through search results as well

List of specifics:
- Product Types are viewable
- Links to a product's details are anchored in their names in Product Category and Search Results
- Minor CSS added for flexing 
- product.json fixtures updated for easy data testing Use `python manage.py loaddata product`