### PR TITLE
kw-orderproduct-delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ media/
 *.pyc
 *.db
 *.pid
+SQLite.sql
 
 # django migrations
 migrations

--- a/ecommerceapi/models/orderProduct.py
+++ b/ecommerceapi/models/orderProduct.py
@@ -4,7 +4,7 @@ from .product import Product
 
 class OrderProduct(models.Model):
 
-    order = models.ForeignKey(Order, on_delete=models.DO_NOTHING)
-    product = models.ForeignKey(Product, on_delete=models.DO_NOTHING)
+    order = models.ForeignKey(Order, on_delete=models.CASCADE)
+    product = models.ForeignKey(Product, on_delete=models.CASCADE)
 
 


### PR DESCRIPTION
Closes #9 

Summary:
orderProducts are now deleted when their associated orders are deleted

- git fetch --all
- git checkout kw-orderproduct-delete
- python manage.py makemigrations
- python manage.py migrate

Run the following queries in table plus (replacing X and Y with order ids from your database that are associated with the user you would like to test with):

`INSERT into ecommerceapi_orderproduct(order_id, product_id)`
`VALUES (X, 5);`

`INSERT into ecommerceapi_orderproduct(order_id, product_id)`
`VALUES (X, 6);`

`INSERT into ecommerceapi_orderproduct(order_id, product_id)`
`VALUES (Y, 7);`

Specifics:
- in models/orderProduct.py on_delete is now set to CASCADING for both properties
- ensure that when 'cancel' is clicked on an order that has associated products, the order is deleted from the order table and the orderProducts are deleted from the orderProduct table
- after testing the delete, double check that the product in the product table still exists

