### PR TITLE
kw-view-remove-product-listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ media/
 
 # django migrations
 migrations
+
+
+SQLite.sql

--- a/ecommerceapi/fixtures/product.json
+++ b/ecommerceapi/fixtures/product.json
@@ -9,7 +9,7 @@
             "description": "Organic, vegan, fresh squeezed, gluten free",
             "quantity": 5,
             "location": null,
-            "image": "orange_juice.jpeg",
+            "image": null,
             "created_at": "2019-10-23T14:02:23.047Z",
             "product_type_id": 1
         }
@@ -24,7 +24,7 @@
             "description": "It's good when it's good, but dear god it's bad when it's bad",
             "quantity": 5,
             "location": "Nashville",
-            "image": "falafel.jpeg",
+            "image": null,
             "created_at": "2019-10-23T14:02:23.047Z",
             "product_type_id": 1
         }
@@ -39,7 +39,7 @@
             "description": "What? Have you even tried them? They're good.",
             "quantity": 5,
             "location": "Nashville",
-            "image": "ants.jpeg",
+            "image": null,
             "created_at": "2019-10-23T14:02:23.047Z",
             "product_type_id": 1
         }
@@ -54,7 +54,7 @@
             "description": "doesn't sound very good",
             "quantity": 1,
             "location": "Nashville",
-            "image": "piano.jpeg",
+            "image": null,
             "created_at": "2019-05-23T14:09:23.047Z",
             "product_type_id": 2
         }
@@ -69,7 +69,7 @@
             "description": "Kills in one shot, guaranteed.",
             "quantity": 1,
             "location": "Nashville",
-            "image": "death_ray.jpeg",
+            "image": null,
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 3
         }
@@ -84,7 +84,7 @@
             "description": "Alyssa disapproves, but it's still really soft.",
             "quantity": 1,
             "location": "Nashville",
-            "image": "tiger_fur.jpeg",
+            "image": null,
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 4
         }
@@ -99,7 +99,7 @@
             "description": "You can craft the best weapon in the game with this thing.",
             "quantity": 1,
             "location": null,
-            "image": "dragon_tooth.jpeg",
+            "image": null,
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 4
         }
@@ -114,7 +114,7 @@
             "description": "You could make, like a.... uh... cool skirt or something with these.",
             "quantity": 1,
             "location": "Nashville",
-            "image": "pangolin_scales.jpeg",
+            "image": null,
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 4
         }
@@ -129,7 +129,7 @@
             "description": "You can make a fine perfume with this stuff",
             "quantity": 1,
             "location": "Nashville",
-            "image": "whale_fat.jpeg",
+            "image": null,
             "created_at": "2019-04-23T14:09:23.047Z",
             "product_type_id": 4
         }

--- a/ecommerceapi/views/product.py
+++ b/ecommerceapi/views/product.py
@@ -48,9 +48,6 @@ class Product(ViewSet):
         Returns:
             Response -- JSON serialized list of Product 
         """
-        print(request)
-        # customer = Customer.objects.get(user=request.auth.user)
-        # product = ProductModel.objects.all()
 
         user = self.request.query_params.get('user', None)
         if user is not None:

--- a/ecommerceapi/views/product.py
+++ b/ecommerceapi/views/product.py
@@ -49,11 +49,19 @@ class Product(ViewSet):
             Response -- JSON serialized list of Product 
         """
         print(request)
-        customer = Customer.objects.get(user=request.auth.user)
-        product = ProductModel.objects.all()
-        # product = ProductModel.objects.filter(customer=customer)
+        # customer = Customer.objects.get(user=request.auth.user)
+        # product = ProductModel.objects.all()
+
+        user = self.request.query_params.get('user', None)
+        if user is not None:
+            customer = Customer.objects.get(user=request.auth.user)
+            product = ProductModel.objects.filter(customer=customer)
+        else:
+            product = ProductModel.objects.all()
+
         serializer = ProductSerializer(
             product, many=True, context={'request': request})
+        
         return Response(serializer.data)
 
     def create(self, request):

--- a/ecommerceapi/views/product.py
+++ b/ecommerceapi/views/product.py
@@ -47,7 +47,10 @@ class Product(ViewSet):
         Returns:
             Response -- JSON serialized list of Product 
         """
-        product = ProductModel.objects.all()
+        print(request)
+        customer = Customer.objects.get(user=request.auth.user)
+        # product = ProductModel.objects.all()
+        product = ProductModel.objects.filter(customer=customer)
         serializer = ProductSerializer(
             product, many=True, context={'request': request})
         return Response(serializer.data)

--- a/ecommerceapi/views/product.py
+++ b/ecommerceapi/views/product.py
@@ -20,8 +20,8 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
             view_name='product',
             lookup_field='id'
         )
-        fields = fields = ('id', 'title', 'customer', 'price', 'description', 'quantity', 'location', 'image', 'created_at', 'product_type', 'product_type_id')
-
+        fields = ('id', 'title', 'customer', 'price', 'description', 'quantity', 'location', 'image', 'created_at', 'product_type', 'product_type_id')
+        # depth = 1
 
 class Product(ViewSet):
     """Product for Bangazon LLC"""

--- a/ecommerceapi/views/product.py
+++ b/ecommerceapi/views/product.py
@@ -88,3 +88,22 @@ class Product(ViewSet):
 
         return Response(serializer.data)
 
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single product
+
+        Returns:
+            Response -- 200, 404, or 500 status code 
+        """
+
+        try:
+            product = ProductModel.objects.get(pk=pk)
+            product.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except ProductModel.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+

--- a/ecommerceapi/views/product.py
+++ b/ecommerceapi/views/product.py
@@ -49,8 +49,8 @@ class Product(ViewSet):
         """
         print(request)
         customer = Customer.objects.get(user=request.auth.user)
-        # product = ProductModel.objects.all()
-        product = ProductModel.objects.filter(customer=customer)
+        product = ProductModel.objects.all()
+        # product = ProductModel.objects.filter(customer=customer)
         serializer = ProductSerializer(
             product, many=True, context={'request': request})
         return Response(serializer.data)

--- a/ecommerceapi/views/user.py
+++ b/ecommerceapi/views/user.py
@@ -1,0 +1,35 @@
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from django.contrib.auth.models import User
+
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        url = serializers.HyperlinkedIdentityField(
+            view_name='user',
+            lookup_field='id'
+        )
+        fields = ('id', 'first_name', 'last_name', 'url')
+
+class Users(ViewSet):
+    
+    def list(self, request):
+        """Handle GET requests to customers resource
+        Returns:
+            Response -- JSON serialized list of customers
+        """
+        users = User.objects.all()
+        serializer = UserSerializer(users, many=True, context={'request': request})
+        return Response(serializer.data)
+    
+    def retrieve(self, request, pk=None):
+        try: 
+            user = User.objects.get(pk=pk)
+            serializer = UserSerializer(user, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+           return HttpResponseServerError(ex)


### PR DESCRIPTION
Closes #19 
Summary:
- Added conditional on product list to check for user query parameter and filter results for 'my products' page.
- Added destroy method for an individual product.
- Added tests for creating and destroying a product.
- Added 'null' value for image attribute in product fixtures

Instructions:
- git fetch --all
- git checkout kw-view-remove-product-listing
- fetch and checkout branch from front-end pull request
- `python manage.py test`

Please Check:
- Tests are written correctly and that those are the only ones I need to add

Note:
As of now, if a user removes a product listing and the product happens to be in somebody's cart, the OrderProduct will also be deleted. This seems fine for products currently in a cart, but I imagine it would at this moment in time also delete the associated OrderProduct from past orders as well. If we were finishing this app to production, I would say we would want to do a kind of soft delete and keep some record of removed products so that we could still access their info once 'removed' if need be. However, I doubt we will actually get to the point of coding that particular stretch goal.