### PR TITLE
fixed null bug in product creation

### DIFF
--- a/ecommerceapi/views/product.py
+++ b/ecommerceapi/views/product.py
@@ -21,7 +21,7 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
             view_name='product',
             lookup_field='id'
         )
-        fields = ('id', 'title', 'customer', 'price', 'description', 'quantity', 'location', 'image', 'created_at', 'product_type', 'product_type_id')
+        fields = ('id', 'title', 'customer_id', 'customer', 'price', 'description', 'quantity', 'location', 'image', 'created_at', 'product_type', 'product_type_id')
         # depth = 1
 
 class Product(ViewSet):
@@ -74,8 +74,14 @@ class Product(ViewSet):
         new_product.price = request.data["price"]
         new_product.description = request.data["description"] 
         new_product.quantity = request.data["quantity"]
-        new_product.location = request.data["location"]
-        new_product.image = request.data["image"]
+        if request.data["location"] == "null":
+            new_product.location = None
+        else:
+            new_product.location = request.data["location"]
+        if request.data["image"] == "null":
+            new_product.image = None
+        else:
+            new_product.image = request.data["image"]
 
         new_product.save()
 
@@ -103,4 +109,15 @@ class Product(ViewSet):
             
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    
+    def update(self, request, pk=None):
+        """Handle PUT requests for an individual order item
+        Returns:
+            Response -- Empty body with 204 status code
+        """
+        product = ProductModel.objects.get(pk=pk)
+        product.quantity = request.data["quantity"]
+        product.save()
+
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
closes #29

git fetch --all

git checkout cn-quantityUpdate

Summary of this pull request:
Each user can update the quantity of only the products they have listed.

List of specifics:

-product.py refactored to always post NULL to images and location if "null" string is a value in the form data


To test:

View products being sold by the user currently logged in. Make sure there is a functional update button. Check for successful updates in the database
View products being sold by other users. Make sure there is no update button.

Make sure that if no local delivery is specified when creating a product and/or no image is uploaded, the final value of "location" and "image" for that product in the database is NULL